### PR TITLE
Adds Script to Auto Convert Input/Output Files to UNIX

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -77,10 +77,10 @@ echo "FILES COPIED TO /home/$WATID/projects/$PROJ_DIR"
 
 ssh -i ece_key $WATID@eceubuntu$SERVER_NUM.uwaterloo.ca "
 cd /home/$WATID/projects/$PROJ_DIR;
-echo 'CONVERTING *.in AND *.out FILES TO UNIX TYPE'
-dos2unix *.in
-dos2unix *.out
-echo 'CONVERSION COMPLETE'
+echo 'CONVERTING *.in AND *.out FILES TO UNIX TYPE';
+dos2unix *.in;
+dos2unix *.out;
+echo 'CONVERSION COMPLETE';
 $MAKE_CMD
 exit;
 "

--- a/start.sh
+++ b/start.sh
@@ -77,6 +77,10 @@ echo "FILES COPIED TO /home/$WATID/projects/$PROJ_DIR"
 
 ssh -i ece_key $WATID@eceubuntu$SERVER_NUM.uwaterloo.ca "
 cd /home/$WATID/projects/$PROJ_DIR;
+echo 'CONVERTING *.in AND *.out FILES TO UNIX TYPE'
+dos2unix *.in
+dos2unix *.out
+echo 'CONVERSION COMPLETE'
 $MAKE_CMD
 exit;
 "

--- a/test.sh
+++ b/test.sh
@@ -73,6 +73,10 @@ echo "FILES COPIED TO /home/$WATID/projects/$PROJ_DIR"
 
 ssh -i ece_key $WATID@eceubuntu$SERVER_NUM.uwaterloo.ca "
 cd /home/$WATID/projects/$PROJ_DIR;
+echo 'CONVERTING *.in AND *.out FILES TO UNIX TYPE'
+dos2unix *.in
+dos2unix *.out
+echo 'CONVERSION COMPLETE'
 echo 'CLEANING...';
 rm a.out;
 echo 'COMPILING...';

--- a/test.sh
+++ b/test.sh
@@ -73,10 +73,10 @@ echo "FILES COPIED TO /home/$WATID/projects/$PROJ_DIR"
 
 ssh -i ece_key $WATID@eceubuntu$SERVER_NUM.uwaterloo.ca "
 cd /home/$WATID/projects/$PROJ_DIR;
-echo 'CONVERTING *.in AND *.out FILES TO UNIX TYPE'
-dos2unix *.in
-dos2unix *.out
-echo 'CONVERSION COMPLETE'
+echo 'CONVERTING *.in AND *.out FILES TO UNIX TYPE';
+dos2unix *.in;
+dos2unix *.out;
+echo 'CONVERSION COMPLETE';
 echo 'CLEANING...';
 rm a.out;
 echo 'COMPILING...';


### PR DESCRIPTION
If users download these files onto a windows computer, there is a good chance the file type will be changed to CRLF. 
This way, we ensure that they do not experience said issue.

Note: I have not tested this, as I do not use the scripts.
If someone could make sure this works as intended, that would be great.